### PR TITLE
Bug fix in VectorView

### DIFF
--- a/include/blockoperator.hpp
+++ b/include/blockoperator.hpp
@@ -93,6 +93,8 @@ class BlockOperator : public Operator
 
         mutable BlockVector<double> x_;
         mutable BlockVector<double> y_;
+
+        mutable Vector<double> tmp_;
 };
 
 } //namespace linalgcpp

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -118,10 +118,7 @@ Vector<T>::Vector(int size)
 {
     data_.resize(size);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -129,10 +126,7 @@ Vector<T>::Vector(int size, T val)
 {
     data_.resize(size, val);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -142,10 +136,7 @@ Vector<T>::Vector(const T* data, int size)
     assert(size >= 0);
     assert(size == 0 || data);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -154,10 +145,7 @@ Vector<T>::Vector(const VectorView<T>& vect)
     data_.resize(vect.size());
     std::copy(std::begin(vect), std::end(vect), std::begin(data_));
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -165,20 +153,14 @@ Vector<T>::Vector(std::vector<T> vect)
 {
     std::swap(vect, data_);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
 Vector<T>::Vector(const Vector<T>& vect) noexcept
     : data_(vect.data_)
 {
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -186,10 +168,7 @@ Vector<T>::Vector(Vector<T>&& vect) noexcept
 {
     swap(*this, vect);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -199,10 +178,7 @@ void Vector<T>::SetSize(int size)
 
     data_.resize(size);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -212,10 +188,7 @@ void Vector<T>::SetSize(int size, T val)
 
     data_.resize(size, val);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 }
 
 template <typename T>
@@ -224,10 +197,7 @@ Vector<T>& Vector<T>::operator=(const Vector<T>& vect) noexcept
     data_.resize(vect.size());
     std::copy(std::begin(vect.data_), std::end(vect.data_), std::begin(data_));
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 
     return *this;
 }
@@ -238,10 +208,7 @@ Vector<T>& Vector<T>::operator=(const VectorView<T>& vect) noexcept
     data_.resize(vect.size());
     std::copy(std::begin(vect), std::end(vect), std::begin(data_));
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 
     return *this;
 }
@@ -251,10 +218,7 @@ Vector<T>& Vector<T>::operator=(Vector<T>&& vect) noexcept
 {
     swap(*this, vect);
 
-    if (data_.size() > 0)
-    {
-        VectorView<T>::SetData(data_.data(), data_.size());
-    }
+    VectorView<T>::SetData(data_.data(), data_.size());
 
     return *this;
 }

--- a/src/blockoperator.cpp
+++ b/src/blockoperator.cpp
@@ -97,7 +97,7 @@ void BlockOperator::Mult(const VectorView<double>& input, VectorView<double> out
     for (int i = 0; i < row_blocks; ++i)
     {
         VectorView<double> row_y {y_.GetBlock(i)};
-        Vector<double> tmp_y(row_y.size());;
+        tmp_.SetSize(row_y.size());
 
         for (int j = 0; j < col_blocks; ++j)
         {
@@ -105,8 +105,8 @@ void BlockOperator::Mult(const VectorView<double>& input, VectorView<double> out
 
             if (op)
             {
-                op->Mult(x_.GetBlock(j), tmp_y);
-                row_y += tmp_y;
+                op->Mult(x_.GetBlock(j), tmp_);
+                row_y += tmp_;
             }
         }
     }
@@ -129,7 +129,7 @@ void BlockOperator::MultAT(const VectorView<double>& input, VectorView<double> o
     for (int j = 0; j < col_blocks; ++j)
     {
         VectorView<double> row_x {x_.GetBlock(j)};
-        Vector<double> tmp_x(row_x.size());;
+        tmp_.SetSize(row_x.size());
 
         for (int i = 0; i < row_blocks; ++i)
         {
@@ -139,9 +139,9 @@ void BlockOperator::MultAT(const VectorView<double>& input, VectorView<double> o
             {
                 VectorView<double> row_block = y_.GetBlock(i);
 
-                op->MultAT(row_block, tmp_x);
+                op->MultAT(row_block, tmp_);
 
-                row_x += tmp_x;
+                row_x += tmp_;
             }
         }
     }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -746,6 +746,19 @@ void test_vector()
 
     std::cout << "v3 normalized:" << v3;
 
+    v3.SetSize(0);
+    std::cout << "v3 zero size:" << v3;
+
+    v3.SetSize(8, 8.0);
+    std::cout << "v3 8 size and fill:" << v3;
+
+    v3.SetSize(2);
+    std::cout << "v3 2 size:" << v3;
+
+    v3.SetSize(size);
+    v3 = 3.0;
+    std::cout << "v3 5 size and op equal 3:" << v3;
+
     std::cout << "v3_copy:" << v3_copy;
     std::cout << "v3_equal:" << v3_equal;
 


### PR DESCRIPTION
There was a bug where `vector.SetSize(0)` did not set the size because of the guards.  I think the guards where there to prevent `data.data()` if `data.size() == 0`, but it seems to work fine w/o them now (tested in test cases).

Also avoids memory allocation every time `BlockOperator::Mult` is called.